### PR TITLE
Fix: trigger on master / cronjob

### DIFF
--- a/.github/workflows/generate-cred.yml
+++ b/.github/workflows/generate-cred.yml
@@ -1,9 +1,12 @@
 name: generate-cred
 
 on:
-  pull_request: []
+  # Trigger on merging to master.
+  push: 
+    branches: 
+      - master
+  # As well as every 6 hours.
   schedule:
-    # Every 6 hours
     - cron: 0 */6 * * *
 
 jobs:


### PR DESCRIPTION
Currently the updates reverted to PRs, as they were during testing. This should be on updates to master and the cronjob instead.

Updates to master, to quickly reflect config changes, such as adding identities / changing weights. Note: the action also commits to master, however I'm expecting GH will detect this without going into an infinite loop.

The cronjob to include newer contributions even without config changes.