### PR TITLE
Add mZ (me) to identities

### DIFF
--- a/project.json
+++ b/project.json
@@ -30,7 +30,8 @@
       {"username": "peth-yursick", "aliases": ["github/peth-yursick", "discord/370936911268806667"]},
       {"username": "sbutler-gh", "aliases": ["github/sbutler-gh"]},
       {"username": "moarshy", "aliases": ["github/moarshy"]},
-      {"username": "AlexMasmej", "aliases": ["github/AlexMasmej", "discord/386587341117980673", "discourse/alexmasmej"]}
+      {"username": "AlexMasmej", "aliases": ["github/AlexMasmej", "discord/386587341117980673", "discourse/alexmasmej"]},
+      {"username": "mZ", "aliases": ["github/mzargham", "discord/250086586450968576", "discourse/mzargham"]
     ],
     "repoIds": [
       {

--- a/project.json
+++ b/project.json
@@ -31,8 +31,8 @@
       {"username": "sbutler-gh", "aliases": ["github/sbutler-gh"]},
       {"username": "moarshy", "aliases": ["github/moarshy"]},
       {"username": "AlexMasmej", "aliases": ["github/AlexMasmej", "discord/386587341117980673", "discourse/alexmasmej"]},
-      {"username": "mZ", "aliases": ["github/mzargham", "discord/250086586450968576", "discourse/mzargham"]
-    ],
+      {"username": "mZ", "aliases": ["github/mzargham", "discord/250086586450968576", "discourse/mzargham"]},
+      ],
     "repoIds": [
       {
         "name": "metagame-web",


### PR DESCRIPTION
This commit adds a record to the identity resolution data structure to merge mZ's github, discourse and discord profiles into one metagame player