### PR TITLE
fixed username causing error

### DIFF
--- a/addressbook.json
+++ b/addressbook.json
@@ -1332,7 +1332,7 @@
     "discordId": "336997676765675532"
   },
   {
-    "name": "ٴٴ",
+    "name": "bigjax.eth",
     "createdAt": 1627390544870,
     "address": "0xfc78F07986381160033383562A0B208CFD00DbA2",
     "discordId": "164354083443048448"


### PR DESCRIPTION
bigjax's username consisted out of certain characters which caused an error in reading the file. 

Changed the account name manually